### PR TITLE
feat(ci): add ansible execution environment inputs to release workflow

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -178,6 +178,16 @@ on:
         type: string
         required: false
         default: ''
+      is-ansible-ee:
+        description: 'Build Ansible Execution Environment instead of standard Docker'
+        type: boolean
+        required: false
+        default: false
+      ee-definition-file:
+        description: 'Path to execution-environment.yml for Ansible EE build'
+        type: string
+        required: false
+        default: 'execution-environment.yml'
 
     secrets:
       github-token:
@@ -271,6 +281,8 @@ jobs:
           version: ${{ needs.detect.outputs.version }}
           image-name: ${{ inputs.ghcr-image-name }}
           additional-tags: ${{ inputs.ghcr-tags }}
+          is-ansible-ee: ${{ inputs.is-ansible-ee }}
+          ee-definition-file: ${{ inputs.ee-definition-file }}
 
   build-helm:
     name: Build Helm

--- a/docs/release-artifacts.md
+++ b/docs/release-artifacts.md
@@ -165,6 +165,19 @@ jobs:
       ghcr-image-name: my-app
 ```
 
+## Ansible-Specific Inputs
+
+| Input | Type | Default | Description |
+|-------|------|---------|-------------|
+| `ansible-collection-path` | string | `''` | Path to Ansible collection directory (e.g., `collections/ansible_collections/myorg/mycollection`) |
+| `is-ansible-ee` | boolean | `false` | Build Ansible Execution Environment instead of standard Docker image |
+| `ee-definition-file` | string | `'execution-environment.yml'` | Path to execution-environment.yml definition file |
+
+When `is-ansible-ee` is `true`:
+- The Docker build step uses `ansible-builder` instead of `docker build`
+- The EE image is built using the specified `execution-environment.yml`
+- The image is tagged with the version and pushed to GHCR
+
 ## Inputs
 
 See [`release-artifacts.yml`](.github/workflows/release-artifacts.yml) for all available inputs.


### PR DESCRIPTION
This PR adds Ansible Execution Environment build inputs to the reusable release workflow.

## Changes
- Add "is-ansible-ee" boolean input to toggle EE builds
- Add "ee-definition-file" input for execution-environment.yml path
- Pass inputs to build-docker composite action
- Document ansible-specific inputs in release-artifacts.md

## Why
The caller workflow in ansible-collection-setup needs to pass these inputs to build the execution environment. Previously these inputs existed in the build-docker composite action but were not exposed in the main reusable workflow.

## Testing
- Verified inputs are passed correctly to build-docker action
- Updated docs with example usage

## Related
- ansible-collection-setup release workflow caller