### PR TITLE
fix(ci): remove invalid timeout-minutes from composite action steps

### DIFF
--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -257,7 +257,6 @@ runs:
     - name: Run unit tests
       if: steps.test-cmd.outputs.command != '' && inputs.run-unit-tests == 'true'
       shell: bash
-      timeout-minutes: ${{ fromJSON(inputs.test-timeout) }}
       run: |
         echo "Running unit tests..."
         CMD="${{ steps.test-cmd.outputs.command }}"
@@ -313,7 +312,6 @@ runs:
     - name: Run integration tests
       if: steps.test-cmd.outputs.command != '' && inputs.run-integration-tests == 'true'
       shell: bash
-      timeout-minutes: ${{ fromJSON(inputs.test-timeout) }}
       run: |
         echo "Running integration tests..."
         TECH="${{ inputs.technology }}"
@@ -365,7 +363,6 @@ runs:
     - name: Run e2e tests
       if: inputs.run-e2e-tests == 'true'
       shell: bash
-      timeout-minutes: ${{ fromJSON(inputs.test-timeout) }}
       run: |
         echo "Running e2e tests..."
         TECH="${{ inputs.technology }}"


### PR DESCRIPTION
Fixes failing workflows in downstream repos.

**Problem:**
The  composite action had  at the step level (lines 260, 316, 368). This is invalid syntax for GitHub Actions composite actions — composite actions do not support  on individual steps.

**Error observed:**


**Fix:**
Remove the three  lines from the composite action steps.

**Note:** Timeouts should be handled at the workflow level (in the reusable workflow or caller workflow), not in the composite action itself.