### PR TITLE
fix(ci): parse version from custom version-source input

### DIFF
--- a/.github/actions/detect-version/action.yml
+++ b/.github/actions/detect-version/action.yml
@@ -26,6 +26,23 @@ runs:
         # If custom version source provided, use it
         if [ "${{ inputs.version-source }}" != "auto" ] && [ -f "${{ inputs.version-source }}" ]; then
           VERSION_FILE="${{ inputs.version-source }}"
+          case "$VERSION_FILE" in
+            *.yml|*.yaml)
+              VERSION=$(grep "^version:" "$VERSION_FILE" | head -1 | sed 's/version: //' | tr -d ' "')
+              ;;
+            *.json)
+              VERSION=$(grep '"version"' "$VERSION_FILE" | head -1 | sed 's/.*"version": "\(.*\)".*/\1/')
+              ;;
+            *.toml)
+              VERSION=$(grep "^version" "$VERSION_FILE" | head -1 | sed 's/version = //' | tr -d ' "')
+              ;;
+            *.py)
+              VERSION=$(grep "version=" "$VERSION_FILE" | head -1 | sed "s/.*version='\(.*\)'.*$/\1/" | sed 's/.*version="\(.*\)".*$/\1/')
+              ;;
+            *)
+              VERSION=$(cat "$VERSION_FILE" | tr -d ' \n')
+              ;;
+          esac
         fi
         
         # Auto-detect from standard files (priority order)


### PR DESCRIPTION
Fixes detect-version action failing when custom version-source is provided.

**Problem:** When a custom version-source path was provided (e.g., collections/ansible_collections/calaviaorg/setup/galaxy.yml), the action only set VERSION_FILE but never extracted the VERSION from it. This caused the detect job to always fail with 'No version detected'.

**Fix:** Added a case statement to parse the version based on file extension:
- .yml/.yaml: grep for 'version:' line
- .json: grep for 'version' line
- .toml: grep for 'version =' line
- .py: grep for 'version=' line
- other: read entire file as version string

**Tested:** Workflow dispatch 27195947504 confirmed the pipeline stops when detect fails (PR #13 fix). This fix resolves the detect failure itself.