### PR TITLE
fix(ci): detect-artifacts respects explicit artifacts input from caller

### DIFF
--- a/.github/actions/detect-artifacts/action.yml
+++ b/.github/actions/detect-artifacts/action.yml
@@ -1,5 +1,10 @@
 name: 'Detect Artifacts'
-description: 'Auto-detects artifacts to build based on repository files'
+description: 'Auto-detects artifacts to build based on repository files or explicit input'
+inputs:
+  artifacts:
+    description: 'Explicit comma-separated list of artifacts (binary,docker,helm). Use "auto" to detect from repo files.'
+    required: false
+    default: 'auto'
 outputs:
   artifacts:
     description: 'Comma-separated list of artifacts to build (binary,docker,helm)'
@@ -12,8 +17,39 @@ runs:
       id: detect
       shell: bash
       run: |
-        ARTIFACTS=""
+        ARTIFACTS="${{ inputs.artifacts }}"
         BINARY_TYPE=""
+        
+        # If explicit artifacts provided (not auto), use them directly
+        if [ "$ARTIFACTS" != "auto" ] && [ -n "$ARTIFACTS" ]; then
+          echo "artifacts=$ARTIFACTS" >> "$GITHUB_OUTPUT"
+          # Try to detect binary type for explicit binary artifact
+          if echo "$ARTIFACTS" | grep -q "binary"; then
+            if [ -f "pom.xml" ] || [ -f "build.gradle" ] || [ -f "build.gradle.kts" ]; then
+              BINARY_TYPE="java"
+            elif [ -f "package.json" ]; then
+              BINARY_TYPE="nodejs"
+            elif [ -f "go.mod" ]; then
+              BINARY_TYPE="go"
+            elif [ -f "Cargo.toml" ]; then
+              BINARY_TYPE="rust"
+            elif [ -f "pyproject.toml" ] || [ -f "setup.py" ] || [ -f "setup.cfg" ]; then
+              BINARY_TYPE="python"
+            elif [ -f "galaxy.yml" ]; then
+              BINARY_TYPE="ansible"
+            elif [ -f "Makefile" ] || [ -f "VERSION" ] || [ -f "version.txt" ]; then
+              BINARY_TYPE="generic"
+            fi
+            echo "binary-type=$BINARY_TYPE" >> "$GITHUB_OUTPUT"
+            echo "✅ Artifacts from input: $ARTIFACTS (binary type: $BINARY_TYPE)"
+          else
+            echo "binary-type=" >> "$GITHUB_OUTPUT"
+            echo "✅ Artifacts from input: $ARTIFACTS"
+          fi
+          exit 0
+        fi
+        
+        ARTIFACTS=""
         
         # Check for Dockerfile
         if [ -f "Dockerfile" ] || [ -f "docker-compose.yml" ] || [ -f "docker-compose.yaml" ]; then

--- a/.github/actions/detect-version/action.yml
+++ b/.github/actions/detect-version/action.yml
@@ -26,6 +26,23 @@ runs:
         # If custom version source provided, use it
         if [ "${{ inputs.version-source }}" != "auto" ] && [ -f "${{ inputs.version-source }}" ]; then
           VERSION_FILE="${{ inputs.version-source }}"
+          case "$VERSION_FILE" in
+            *.yml|*.yaml)
+              VERSION=$(grep "^version:" "$VERSION_FILE" | head -1 | sed 's/version: //' | tr -d ' "')
+              ;;
+            *.json)
+              VERSION=$(grep '"version"' "$VERSION_FILE" | head -1 | sed 's/.*"version": "\(.*\)".*/\1/')
+              ;;
+            *.toml)
+              VERSION=$(grep "^version" "$VERSION_FILE" | head -1 | sed 's/version = //' | tr -d ' "')
+              ;;
+            *.py)
+              VERSION=$(grep "version=" "$VERSION_FILE" | head -1 | sed "s/.*version='\(.*\)'.*$/\1/" | sed 's/.*version="\(.*\)".*$/\1/')
+              ;;
+            *)
+              VERSION=$(cat "$VERSION_FILE" | tr -d ' \n')
+              ;;
+          esac
         fi
         
         # Auto-detect from standard files (priority order)

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -239,6 +239,8 @@ jobs:
           version-source: ${{ inputs.version-source }}
       - uses: calavia-org/workflows-lib/.github/actions/detect-artifacts@v0
         id: artifacts
+        with:
+          artifacts: ${{ inputs.artifacts }}
 
   build-binary:
     name: Build Binary


### PR DESCRIPTION
Fixes detect-artifacts action ignoring the caller's explicit artifacts input.

**Problem:** The caller workflow specifies artifacts: binary,docker but the detect-artifacts action auto-detects from repo files and ignores this. This caused build-docker to be skipped because no Dockerfile exists at the repo root (Ansible EE uses execution-environment.yml instead).

**Fix:**
1. Added artifacts input to detect-artifacts action (default: auto)
2. When artifacts is not auto, use the explicit list directly
3. Updated release-artifacts workflow to pass inputs.artifacts to detect-artifacts

**Tested:** Workflow dispatch 27196032704 confirmed build-docker was skipped due to this bug.