### PR TITLE
fix(ci): add value mappings to composite action outputs

### DIFF
--- a/.github/actions/detect-artifacts/action.yml
+++ b/.github/actions/detect-artifacts/action.yml
@@ -8,8 +8,10 @@ inputs:
 outputs:
   artifacts:
     description: 'Comma-separated list of artifacts to build (binary,docker,helm)'
+    value: ${{ steps.detect.outputs.artifacts }}
   binary-type:
     description: 'Type of binary artifact (java,nodejs,go,python,rust,ansible,generic)'
+    value: ${{ steps.detect.outputs.binary-type }}
 runs:
   using: composite
   steps:

--- a/.github/actions/detect-version/action.yml
+++ b/.github/actions/detect-version/action.yml
@@ -8,10 +8,13 @@ inputs:
 outputs:
   version:
     description: 'Detected version string'
+    value: ${{ steps.detect.outputs.version }}
   version-file:
     description: 'Path to the version file used'
+    value: ${{ steps.detect.outputs.version-file }}
   technology:
     description: 'Detected technology'
+    value: ${{ steps.detect.outputs.technology }}
 runs:
   using: composite
   steps:


### PR DESCRIPTION
Fixes composite actions not exposing outputs to calling workflows.

**Problem:** Composite actions in workflows-lib were missing the required  property in their  definitions. This caused the calling workflow to receive empty outputs, leading to downstream jobs being skipped.

**Affected actions:**
-  - outputs  and  were empty
-  - outputs , , and  were empty

**Fix:** Added  mappings to properly expose step outputs to the calling workflow:
- 

**Evidence:** Workflow run 27196130895 showed detect succeeded but build-binary and build-docker were skipped because  was empty.