### PR TITLE
fix(ci): add value mappings to all composite action outputs

### DIFF
--- a/.github/actions/build-binary/action.yml
+++ b/.github/actions/build-binary/action.yml
@@ -42,8 +42,10 @@ inputs:
 outputs:
   artifact-path:
     description: 'Path to built binary artifact'
+    value: ${{ steps.build.outputs.artifact-path }}
   artifact-name:
     description: 'Name of the artifact'
+    value: ${{ steps.build.outputs.artifact-name }}
 runs:
   using: composite
   steps:

--- a/.github/actions/build-docker/action.yml
+++ b/.github/actions/build-docker/action.yml
@@ -35,8 +35,10 @@ inputs:
 outputs:
   image-tag:
     description: 'Full image tag with version'
+    value: ${{ steps.build.outputs.image-tag }}
   image-name:
     description: 'Image name'
+    value: ${{ steps.build.outputs.image-name }}
 runs:
   using: composite
   steps:

--- a/.github/actions/build-helm/action.yml
+++ b/.github/actions/build-helm/action.yml
@@ -22,8 +22,10 @@ inputs:
 outputs:
   chart-path:
     description: 'Path to packaged chart'
+    value: ${{ steps.build.outputs.chart-path }}
   chart-name:
     description: 'Name of the chart'
+    value: ${{ steps.build.outputs.chart-name }}
 runs:
   using: composite
   steps:

--- a/.github/actions/detect-technology/action.yml
+++ b/.github/actions/detect-technology/action.yml
@@ -3,8 +3,10 @@ description: 'Detects the technology stack of the repository based on file indic
 outputs:
   technologies:
     description: 'Comma-separated list of detected technologies'
+    value: ${{ steps.detect.outputs.technologies }}
   primary:
     description: 'Primary technology for the repository'
+    value: ${{ steps.detect.outputs.primary }}
 runs:
   using: composite
   steps:

--- a/.github/actions/generate-release-notes/action.yml
+++ b/.github/actions/generate-release-notes/action.yml
@@ -15,6 +15,7 @@ inputs:
 outputs:
   notes:
     description: 'Generated release notes'
+    value: ${{ steps.notes.outputs.notes }}
 runs:
   using: composite
   steps:

--- a/.github/actions/publish-ghcr/action.yml
+++ b/.github/actions/publish-ghcr/action.yml
@@ -14,6 +14,7 @@ inputs:
 outputs:
   pushed-tags:
     description: 'Comma-separated list of pushed tags'
+    value: ${{ steps.push.outputs.pushed-tags }}
 runs:
   using: composite
   steps:

--- a/.github/actions/publish-github-release/action.yml
+++ b/.github/actions/publish-github-release/action.yml
@@ -30,8 +30,10 @@ inputs:
 outputs:
   release-url:
     description: 'URL to the created release'
+    value: ${{ steps.release.outputs.url }}
   release-id:
     description: 'ID of the created release'
+    value: ${{ steps.release.outputs.id }}
 runs:
   using: composite
   steps:

--- a/.github/actions/publish-helm/action.yml
+++ b/.github/actions/publish-helm/action.yml
@@ -17,6 +17,7 @@ inputs:
 outputs:
   chart-url:
     description: 'URL to published chart'
+    value: ${{ steps.push.outputs.chart-url }}
 runs:
   using: composite
   steps:

--- a/.github/actions/publish-package/action.yml
+++ b/.github/actions/publish-package/action.yml
@@ -31,6 +31,7 @@ inputs:
 outputs:
   publish-url:
     description: 'URL to published package'
+    value: ${{ steps.publish.outputs.publish-url }}
 runs:
   using: composite
   steps:

--- a/.github/actions/rollback-release/action.yml
+++ b/.github/actions/rollback-release/action.yml
@@ -15,6 +15,7 @@ inputs:
 outputs:
   rollback-status:
     description: 'Status of rollback'
+    value: ${{ steps.notify.outputs.rollback-status }}
 runs:
   using: composite
   steps:

--- a/.github/actions/sign-binary/action.yml
+++ b/.github/actions/sign-binary/action.yml
@@ -14,6 +14,7 @@ inputs:
 outputs:
   signature-path:
     description: 'Path to signature file'
+    value: ${{ steps.sign.outputs.signature-path }}
 runs:
   using: composite
   steps:

--- a/.github/actions/sign-docker/action.yml
+++ b/.github/actions/sign-docker/action.yml
@@ -14,6 +14,7 @@ inputs:
 outputs:
   signature-path:
     description: 'Path to signature file'
+    value: ${{ steps.sign.outputs.signature-path }}
 runs:
   using: composite
   steps:

--- a/.github/actions/sign-helm/action.yml
+++ b/.github/actions/sign-helm/action.yml
@@ -14,6 +14,7 @@ inputs:
 outputs:
   provenance-path:
     description: 'Path to provenance file'
+    value: ${{ steps.sign.outputs.provenance-path }}
 runs:
   using: composite
   steps:


### PR DESCRIPTION
Fixes a systemic bug where composite action outputs were not exposed to calling workflows.

**Problem:** Composite actions require explicit value mappings in their outputs section to pass step outputs to the calling workflow. Without these, all outputs were empty, causing downstream jobs to fail or be skipped.

**Affected actions (13 files):**
- build-binary: artifact-path, artifact-name
- build-docker: image-tag, image-name
- build-helm: chart-path, chart-name
- detect-technology: technologies, primary
- generate-release-notes: notes
- publish-ghcr: pushed-tags
- publish-github-release: release-url, release-id
- publish-helm: chart-url
- publish-package: publish-url
- rollback-release: rollback-status
- sign-binary: signature-path
- sign-docker: signature-path
- sign-helm: provenance-path

**Evidence:** Workflow run 27196295147 showed build-docker succeeded but publish-ghcr received IMAGE="" because image-tag output was empty.