### PR TITLE
fix(ci): transfer docker image between jobs via artifact

### DIFF
--- a/.github/actions/build-docker/action.yml
+++ b/.github/actions/build-docker/action.yml
@@ -91,3 +91,15 @@ runs:
         echo "image-tag=$FULL_TAG" >> "$GITHUB_OUTPUT"
         echo "image-name=$IMAGE_NAME" >> "$GITHUB_OUTPUT"
         echo "✅ Built image: $FULL_TAG"
+    - name: Save Docker image
+      shell: bash
+      run: |
+        FULL_TAG="${{ steps.build.outputs.image-tag }}"
+        docker save "$FULL_TAG" -o docker-image.tar
+        echo "✅ Saved image to docker-image.tar"
+    - name: Upload artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: docker-image
+        path: docker-image.tar
+        retention-days: 7

--- a/.github/actions/publish-ghcr/action.yml
+++ b/.github/actions/publish-ghcr/action.yml
@@ -18,10 +18,24 @@ outputs:
 runs:
   using: composite
   steps:
+    - name: Download Docker image artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: docker-image
+        path: .
+    - name: Load Docker image
+      shell: bash
+      run: |
+        if [ -f "docker-image.tar" ]; then
+          docker load -i docker-image.tar
+          echo "✅ Loaded image from artifact"
+        else
+          echo "⚠️ No docker-image.tar found, image may already be built locally"
+        fi
     - name: Log in to GHCR
       uses: docker/login-action@v3
       with:
-        registry: ghcr.io
+        registry: ghcr
         username: ${{ github.actor }}
         password: ${{ inputs.github-token }}
     - name: Push image


### PR DESCRIPTION
Fixes publish-ghcr failing because the Docker image built in build-docker job doesn't exist on the publish-ghcr runner.

**Problem:** Each GitHub Actions job runs on a fresh runner. The build-docker job builds and tags the image, but the publish-ghcr job receives an empty runner and can't find the image locally.

**Fix:**
1. build-docker action: Save the image as a tar file using docker save and upload it as an artifact named docker-image
2. publish-ghcr action: Download the artifact and load the image using docker load before pushing

**Evidence:** Workflow run 27199856645 showed build-docker succeeded but publish-ghcr failed with 'An image does not exist locally with the tag'