### PR TITLE
fix(ci): correct GHCR registry URL to ghcr.io

### DIFF
--- a/.github/actions/publish-ghcr/action.yml
+++ b/.github/actions/publish-ghcr/action.yml
@@ -35,7 +35,7 @@ runs:
     - name: Log in to GHCR
       uses: docker/login-action@v3
       with:
-        registry: ghcr
+        registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ inputs.github-token }}
     - name: Push image


### PR DESCRIPTION
Fixes docker login failing because registry URL was set to ghcr instead of ghcr.io.

**Error:** Get https://ghcr/v2/: dial tcp: lookup ghcr on 127.0.0.53:53: server misbehaving

**Fix:** Changed registry input from ghcr to ghcr.io