### PR TITLE
fix(ci): generate valid GHCR image names with owner namespace

### DIFF
--- a/.github/actions/build-docker/action.yml
+++ b/.github/actions/build-docker/action.yml
@@ -62,9 +62,11 @@ runs:
         
         if [ -z "$IMAGE_NAME" ]; then
           IMAGE_NAME="${{ github.repository }}"
+        elif ! echo "$IMAGE_NAME" | grep -q '/'; then
+          IMAGE_NAME="${{ github.repository_owner }}/$IMAGE_NAME"
         fi
         
-        IMAGE_NAME=$(echo "$IMAGE_NAME" | tr '[:upper:]' '[:lower:]' | tr '/' '-')
+        IMAGE_NAME=$(echo "$IMAGE_NAME" | tr '[:upper:]' '[:lower:]')
         FULL_TAG="ghcr.io/$IMAGE_NAME:$VERSION"
         
         if [ "${{ inputs.is-ansible-ee }}" == "true" ]; then


### PR DESCRIPTION
Fixes GHCR publish failing with an invalid image name.

The build-docker action was flattening repository paths by converting slashes to dashes, which produced invalid GHCR tags. It now preserves owner/image structure and prefixes github.repository_owner when only an image name is provided.