### PR TITLE
fix(ci): recreate additional GHCR tags before push

### DIFF
--- a/.github/actions/publish-ghcr/action.yml
+++ b/.github/actions/publish-ghcr/action.yml
@@ -57,6 +57,7 @@ runs:
           if [ -n "$tag" ]; then
             BASE=$(echo "$IMAGE" | sed 's/:.*//')
             ADDITIONAL="$BASE:$tag"
+            docker tag "$IMAGE" "$ADDITIONAL"
             docker push "$ADDITIONAL"
             PUSHED="$PUSHED,$ADDITIONAL"
             echo "Pushed: $ADDITIONAL"


### PR DESCRIPTION
Fixes GHCR publish failing after the main image push succeeds.

The publish job loads only the version-tagged image from artifact. It then tried to push additional tags like latest/main without creating them locally first. This change re-tags the loaded image locally before pushing each additional tag.