### PR TITLE
feat(ci): add reusable workflows for GitHub Actions repositories

### DIFF
--- a/.github/actions/build-ee/action.yml
+++ b/.github/actions/build-ee/action.yml
@@ -1,5 +1,5 @@
-name: 'Build Docker'
-description: 'Builds Docker image from Dockerfile'
+name: 'Build Execution Environment'
+description: 'Builds Ansible Execution Environment image using ansible-builder'
 inputs:
   version:
     description: 'Version to tag the image'
@@ -8,18 +8,10 @@ inputs:
     description: 'Image name (default: repo name)'
     required: false
     default: ''
-  dockerfile-path:
-    description: 'Path to Dockerfile'
+  ee-definition-file:
+    description: 'Path to execution-environment.yml'
     required: false
-    default: 'Dockerfile'
-  build-context:
-    description: 'Build context'
-    required: false
-    default: '.'
-  binary-artifact:
-    description: 'Path to binary artifact to include'
-    required: false
-    default: ''
+    default: 'execution-environment.yml'
   additional-tags:
     description: 'Additional tags (comma-separated)'
     required: false
@@ -34,13 +26,10 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: Download binary artifact
-      if: inputs.binary-artifact != ''
-      uses: actions/download-artifact@v4
-      with:
-        name: ${{ inputs.binary-artifact }}
-        path: ./artifact
-    - name: Build Docker image
+    - name: Setup Ansible Builder
+      shell: bash
+      run: pip install ansible-builder
+    - name: Build EE image
       id: build
       shell: bash
       run: |
@@ -56,7 +45,11 @@ runs:
         IMAGE_NAME=$(echo "$IMAGE_NAME" | tr '[:upper:]' '[:lower:]')
         FULL_TAG="ghcr.io/$IMAGE_NAME:$VERSION"
         
-        docker build -f ${{ inputs.dockerfile-path }} -t "$FULL_TAG" ${{ inputs.build-context }}
+        ansible-builder build \
+          --file "${{ inputs.ee-definition-file }}" \
+          --container-runtime docker \
+          --tag "$FULL_TAG" \
+          --tag "ghcr.io/$IMAGE_NAME:latest"
         
         IFS=',' read -ra TAGS <<< "${{ inputs.additional-tags }}"
         for tag in "${TAGS[@]}"; do
@@ -70,13 +63,13 @@ runs:
         
         echo "image-tag=$FULL_TAG" >> "$GITHUB_OUTPUT"
         echo "image-name=$IMAGE_NAME" >> "$GITHUB_OUTPUT"
-        echo "✅ Built image: $FULL_TAG"
+        echo "✅ Built EE image: $FULL_TAG"
     - name: Save Docker image
       shell: bash
       run: |
         FULL_TAG="${{ steps.build.outputs.image-tag }}"
         docker save "$FULL_TAG" -o docker-image.tar
-        echo "✅ Saved image to docker-image.tar"
+        echo "✅ Saved EE image to docker-image.tar"
     - name: Upload artifact
       uses: actions/upload-artifact@v4
       with:

--- a/.github/actions/detect-artifacts/action.yml
+++ b/.github/actions/detect-artifacts/action.yml
@@ -2,12 +2,12 @@ name: 'Detect Artifacts'
 description: 'Auto-detects artifacts to build based on repository files or explicit input'
 inputs:
   artifacts:
-    description: 'Explicit comma-separated list of artifacts (binary,docker,helm). Use "auto" to detect from repo files.'
+    description: 'Explicit comma-separated list of artifacts (binary,docker,execution-environment,helm). Use "auto" to detect from repo files.'
     required: false
     default: 'auto'
 outputs:
   artifacts:
-    description: 'Comma-separated list of artifacts to build (binary,docker,helm)'
+    description: 'Comma-separated list of artifacts to build (binary,docker,execution-environment,helm)'
     value: ${{ steps.detect.outputs.artifacts }}
   binary-type:
     description: 'Type of binary artifact (java,nodejs,go,python,rust,ansible,generic)'
@@ -53,9 +53,18 @@ runs:
         
         ARTIFACTS=""
         
-        # Check for Dockerfile
+        # Check for execution-environment.yml (Ansible EE - distinct from Docker)
+        if [ -f "execution-environment.yml" ] || [ -f "execution-environment.yaml" ]; then
+          ARTIFACTS="execution-environment"
+        fi
+        
+        # Check for Dockerfile (only if not an EE - Docker and EE are mutually exclusive)
         if [ -f "Dockerfile" ] || [ -f "docker-compose.yml" ] || [ -f "docker-compose.yaml" ]; then
-          ARTIFACTS="docker"
+          if [ -n "$ARTIFACTS" ]; then
+            ARTIFACTS="$ARTIFACTS,docker"
+          else
+            ARTIFACTS="docker"
+          fi
         fi
         
         # Check for Helm chart

--- a/.github/actions/publish-ghcr/action.yml
+++ b/.github/actions/publish-ghcr/action.yml
@@ -1,5 +1,5 @@
 name: 'Publish to GHCR'
-description: 'Pushes Docker image to GitHub Container Registry'
+description: 'Pushes container image to GitHub Container Registry'
 inputs:
   image-tag:
     description: 'Full image tag to push'

--- a/.github/actions/rollback-release/action.yml
+++ b/.github/actions/rollback-release/action.yml
@@ -6,7 +6,7 @@ inputs:
     required: false
     default: ''
   image-tags:
-    description: 'Comma-separated Docker image tags to delete'
+    description: 'Comma-separated container image tags to delete'
     required: false
     default: ''
   github-token:

--- a/.github/actions/sign-docker/action.yml
+++ b/.github/actions/sign-docker/action.yml
@@ -1,5 +1,5 @@
-name: 'Sign Docker'
-description: 'Signs Docker image with Cosign'
+name: 'Sign Container'
+description: 'Signs container image with Cosign'
 inputs:
   image-tag:
     description: 'Full image tag to sign'

--- a/.github/workflows/pr-check-github-action.yml
+++ b/.github/workflows/pr-check-github-action.yml
@@ -1,0 +1,224 @@
+name: PR Check GitHub Action
+
+on:
+  workflow_call:
+    inputs:
+      runner-label:
+        description: 'Runner label'
+        type: string
+        required: false
+        default: 'ubuntu-latest'
+      validate-structure:
+        description: 'Validate action.yml required fields'
+        type: boolean
+        required: false
+        default: true
+      run-lint:
+        description: 'Run actionlint on action files'
+        type: boolean
+        required: false
+        default: true
+      run-test:
+        description: 'Test action reference'
+        type: boolean
+        required: false
+        default: false
+      fail-on-missing:
+        description: 'Fail if action.yml not found'
+        type: boolean
+        required: false
+        default: true
+
+jobs:
+  detect:
+    name: Detect Action
+    runs-on: ${{ inputs.runner-label }}
+    timeout-minutes: 5
+    outputs:
+      action-file: ${{ steps.detect.outputs.action-file }}
+      has-version: ${{ steps.detect.outputs.has-version }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Detect action file
+        id: detect
+        shell: bash
+        run: |
+          ACTION_FILE=""
+          HAS_VERSION="false"
+          
+          if [ -f "action.yml" ]; then
+            ACTION_FILE="action.yml"
+          elif [ -f "action.yaml" ]; then
+            ACTION_FILE="action.yaml"
+          fi
+          
+          if [ -z "$ACTION_FILE" ]; then
+            echo "action.yml or action.yaml not found in repository root"
+            if [ "${{ inputs.fail-on-missing }}" == "true" ]; then
+              exit 1
+            fi
+          fi
+          
+          if [ -n "$ACTION_FILE" ] && grep -q "^version:" "$ACTION_FILE" 2>/dev/null; then
+            HAS_VERSION="true"
+          fi
+          
+          echo "action-file=$ACTION_FILE" >> "$GITHUB_OUTPUT"
+          echo "has-version=$HAS_VERSION" >> "$GITHUB_OUTPUT"
+          
+          if [ -n "$ACTION_FILE" ]; then
+            echo "Action file detected: $ACTION_FILE"
+            echo "Has version field: $HAS_VERSION"
+          fi
+
+  validate:
+    name: Validate Structure
+    needs: detect
+    runs-on: ${{ inputs.runner-label }}
+    timeout-minutes: 5
+    if: ${{ inputs.validate-structure && needs.detect.outputs.action-file != '' }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Validate action.yml structure
+        shell: bash
+        run: |
+          ACTION_FILE="${{ needs.detect.outputs.action-file }}"
+          
+          echo "Validating $ACTION_FILE structure..."
+          
+          ERRORS=0
+          
+          # Check name field
+          if ! grep -q "^name:" "$ACTION_FILE"; then
+            echo "ERROR: Missing 'name' field"
+            ERRORS=$((ERRORS + 1))
+          fi
+          
+          # Check description field
+          if ! grep -q "^description:" "$ACTION_FILE"; then
+            echo "ERROR: Missing 'description' field"
+            ERRORS=$((ERRORS + 1))
+          fi
+          
+          # Check runs section
+          if ! grep -q "^runs:" "$ACTION_FILE"; then
+            echo "ERROR: Missing 'runs' section"
+            ERRORS=$((ERRORS + 1))
+          else
+            # Check using field in runs
+            if ! grep -A 5 "^runs:" "$ACTION_FILE" | grep -q "using:"; then
+              echo "ERROR: Missing 'using' field in runs section"
+              ERRORS=$((ERRORS + 1))
+            else
+              # Validate using value
+              USING=$(grep -A 5 "^runs:" "$ACTION_FILE" | grep "using:" | sed 's/.*using: //' | tr -d ' "')
+              case "$USING" in
+                composite|node12|node16|node20|docker)
+                  echo "Valid using: $USING"
+                  ;;
+                *)
+                  echo "ERROR: Invalid 'using' value: $USING (must be composite, node12, node16, node20, or docker)"
+                  ERRORS=$((ERRORS + 1))
+                  ;;
+              esac
+            fi
+          fi
+          
+          # Check for inputs section (optional but validate if present)
+          if grep -q "^inputs:" "$ACTION_FILE"; then
+            echo "Inputs section found"
+          fi
+          
+          # Check for outputs section (optional but validate if present)
+          if grep -q "^outputs:" "$ACTION_FILE"; then
+            echo "Outputs section found"
+          fi
+          
+          if [ $ERRORS -gt 0 ]; then
+            echo "Validation failed with $ERRORS error(s)"
+            exit 1
+          fi
+          
+          echo "Action structure is valid"
+
+  lint:
+    name: Lint Action
+    needs: detect
+    runs-on: ${{ inputs.runner-label }}
+    timeout-minutes: 10
+    if: ${{ inputs.run-lint && needs.detect.outputs.action-file != '' }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Install actionlint
+        shell: bash
+        run: |
+          # Install actionlint
+          curl -sL https://github.com/rhysd/actionlint/releases/latest/download/actionlint_$(uname -s)_$(uname -m).tar.gz | tar xz
+          sudo mv actionlint /usr/local/bin/
+          echo "actionlint installed"
+
+      - name: Run actionlint
+        shell: bash
+        run: |
+          echo "Running actionlint..."
+          
+          # Lint action files
+          if [ -f "action.yml" ]; then
+            actionlint action.yml
+          fi
+          
+          if [ -f "action.yaml" ]; then
+            actionlint action.yaml
+          fi
+          
+          # Also lint any workflow files
+          if [ -d ".github/workflows" ]; then
+            actionlint .github/workflows/*.yml .github/workflows/*.yaml 2>/dev/null || true
+          fi
+          
+          echo "Linting complete"
+
+  test:
+    name: Test Action
+    needs: [detect, validate]
+    runs-on: ${{ inputs.runner-label }}
+    timeout-minutes: 15
+    if: ${{ inputs.run-test && needs.detect.outputs.action-file != '' }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Test action reference
+        shell: bash
+        run: |
+          ACTION_FILE="${{ needs.detect.outputs.action-file }}"
+          
+          echo "Testing action reference..."
+          
+          # Extract action name for testing
+          ACTION_NAME=$(grep "^name:" "$ACTION_FILE" | head -1 | sed 's/name: //' | tr -d ' "')
+          echo "Action name: $ACTION_NAME"
+          
+          # Check if action can be referenced
+          if [ -f "$ACTION_FILE" ]; then
+            echo "Action file exists and is valid YAML"
+            
+            # Verify it can be parsed
+            python3 -c "
+          import yaml
+          with open('$ACTION_FILE') as f:
+              data = yaml.safe_load(f)
+              print('YAML parsed successfully')
+              print(f\"Name: {data.get('name', 'N/A')}\")
+              print(f\"Description: {data.get('description', 'N/A')}\")
+              print(f\"Runs: {data.get('runs', {}).get('using', 'N/A')}\")
+          " 2>/dev/null || echo "Python YAML validation skipped"
+          fi
+          
+          echo "Action reference test complete"

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -178,11 +178,6 @@ on:
         type: string
         required: false
         default: ''
-      is-ansible-ee:
-        description: 'Build Ansible Execution Environment instead of standard Docker'
-        type: boolean
-        required: false
-        default: false
       ee-definition-file:
         description: 'Path to execution-environment.yml for Ansible EE build'
         type: string
@@ -283,15 +278,32 @@ jobs:
           version: ${{ needs.detect.outputs.version }}
           image-name: ${{ inputs.ghcr-image-name }}
           additional-tags: ${{ inputs.ghcr-tags }}
-          is-ansible-ee: ${{ inputs.is-ansible-ee }}
+
+  build-ee:
+    name: Build Execution Environment
+    needs: [detect, build-binary]
+    runs-on: ${{ inputs.runner-label }}
+    timeout-minutes: ${{ inputs.timeout-minutes }}
+    if: ${{ contains(needs.detect.outputs.artifacts, 'execution-environment') }}
+    outputs:
+      image-tag: ${{ steps.build.outputs.image-tag }}
+      image-name: ${{ steps.build.outputs.image-name }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: calavia-org/workflows-lib/.github/actions/build-ee@v0
+        id: build
+        with:
+          version: ${{ needs.detect.outputs.version }}
+          image-name: ${{ inputs.ghcr-image-name }}
+          additional-tags: ${{ inputs.ghcr-tags }}
           ee-definition-file: ${{ inputs.ee-definition-file }}
 
   build-helm:
     name: Build Helm
-    needs: [detect, build-docker]
+    needs: [detect, build-docker, build-ee]
     runs-on: ${{ inputs.runner-label }}
     timeout-minutes: ${{ inputs.timeout-minutes }}
-    if: ${{ contains(needs.detect.outputs.artifacts, 'helm') }}
+    if: ${{ contains(needs.detect.outputs.artifacts, 'helm') && always() && needs.detect.result == 'success' && (needs.build-docker.result == 'success' || needs.build-docker.result == 'skipped') && (needs.build-ee.result == 'success' || needs.build-ee.result == 'skipped') }}
     outputs:
       chart-path: ${{ steps.build.outputs.chart-path }}
       chart-name: ${{ steps.build.outputs.chart-name }}
@@ -303,8 +315,8 @@ jobs:
           version: ${{ needs.detect.outputs.version }}
           app-version: ${{ needs.detect.outputs.version }}
           chart-path: ${{ inputs.helm-chart-path }}
-          image-name: ${{ needs.build-docker.outputs.image-name }}
-          image-tag: ${{ needs.build-docker.outputs.image-tag }}
+          image-name: ${{ needs.build-docker.outputs.image-name || needs.build-ee.outputs.image-name }}
+          image-tag: ${{ needs.build-docker.outputs.image-tag || needs.build-ee.outputs.image-tag }}
 
   sign-binary:
     name: Sign Binary
@@ -321,16 +333,16 @@ jobs:
           gpg-passphrase: ${{ secrets.gpg-passphrase }}
 
   sign-docker:
-    name: Sign Docker
-    needs: [detect, build-docker]
+    name: Sign Container
+    needs: [detect, build-docker, build-ee]
     runs-on: ${{ inputs.runner-label }}
     timeout-minutes: 10
-    if: ${{ inputs.sign-artifacts && inputs.sign-docker && contains(needs.detect.outputs.artifacts, 'docker') }}
+    if: ${{ inputs.sign-artifacts && inputs.sign-docker && always() && needs.detect.result == 'success' && (contains(needs.detect.outputs.artifacts, 'docker') || contains(needs.detect.outputs.artifacts, 'execution-environment')) && (needs.build-docker.result == 'success' || needs.build-docker.result == 'skipped') && (needs.build-ee.result == 'success' || needs.build-ee.result == 'skipped') }}
     steps:
       - uses: actions/checkout@v4
       - uses: calavia-org/workflows-lib/.github/actions/sign-docker@v0
         with:
-          image-tag: ${{ needs.build-docker.outputs.image-tag }}
+          image-tag: ${{ needs.build-docker.outputs.image-tag || needs.build-ee.outputs.image-tag }}
           cosign-key: ${{ secrets.cosign-key }}
 
   sign-helm:
@@ -349,10 +361,10 @@ jobs:
 
   publish-github-release:
     name: Publish GitHub Release
-    needs: [detect, build-binary, build-docker, build-helm, sign-binary, sign-docker, sign-helm]
+    needs: [detect, build-binary, build-docker, build-ee, build-helm, sign-binary, sign-docker, sign-helm]
     runs-on: ${{ inputs.runner-label }}
     timeout-minutes: 10
-    if: ${{ inputs.publish-github-release && always() && needs.detect.result == 'success' && (needs.build-binary.result == 'success' || needs.build-binary.result == 'skipped') && (needs.build-docker.result == 'success' || needs.build-docker.result == 'skipped') && (needs.build-helm.result == 'success' || needs.build-helm.result == 'skipped') }}
+    if: ${{ inputs.publish-github-release && always() && needs.detect.result == 'success' && (needs.build-binary.result == 'success' || needs.build-binary.result == 'skipped') && (needs.build-docker.result == 'success' || needs.build-docker.result == 'skipped') && (needs.build-ee.result == 'success' || needs.build-ee.result == 'skipped') && (needs.build-helm.result == 'success' || needs.build-helm.result == 'skipped') }}
     outputs:
       release-url: ${{ steps.publish.outputs.release-url }}
       release-id: ${{ steps.publish.outputs.release-id }}
@@ -375,14 +387,14 @@ jobs:
 
   publish-ghcr:
     name: Publish to GHCR
-    needs: [detect, build-docker, sign-docker]
+    needs: [detect, build-docker, build-ee, sign-docker]
     runs-on: ${{ inputs.runner-label }}
     timeout-minutes: 10
-    if: ${{ inputs.publish-ghcr && always() && needs.detect.result == 'success' && (needs.build-docker.result == 'success' || needs.build-docker.result == 'skipped') }}
+    if: ${{ inputs.publish-ghcr && always() && needs.detect.result == 'success' && (needs.build-docker.result == 'success' || needs.build-docker.result == 'skipped') && (needs.build-ee.result == 'success' || needs.build-ee.result == 'skipped') }}
     steps:
       - uses: calavia-org/workflows-lib/.github/actions/publish-ghcr@v0
         with:
-          image-tag: ${{ needs.build-docker.outputs.image-tag }}
+          image-tag: ${{ needs.build-docker.outputs.image-tag || needs.build-ee.outputs.image-tag }}
           additional-tags: ${{ inputs.ghcr-tags }}
           github-token: ${{ secrets.github-token || secrets.GITHUB_TOKEN }}
 
@@ -426,7 +438,7 @@ jobs:
       - uses: calavia-org/workflows-lib/.github/actions/rollback-release@v0
         with:
           release-id: ${{ needs.publish-github-release.outputs.release-id }}
-          image-tags: ${{ needs.build-docker.outputs.image-tag }}
+          image-tags: ${{ needs.build-docker.outputs.image-tag || needs.build-ee.outputs.image-tag }}
           github-token: ${{ secrets.github-token || secrets.GITHUB_TOKEN }}
 
   notify:

--- a/.github/workflows/release-github-action.yml
+++ b/.github/workflows/release-github-action.yml
@@ -1,0 +1,173 @@
+name: Release GitHub Action
+
+on:
+  workflow_call:
+    inputs:
+      default-bump:
+        description: 'Default version bump when no conventional commit found (patch, minor, major, none)'
+        type: string
+        required: false
+        default: 'patch'
+      release-branches:
+        description: 'Branches that trigger releases (comma-separated)'
+        type: string
+        required: false
+        default: 'main'
+      tag-prefix:
+        description: 'Prefix for version tags'
+        type: string
+        required: false
+        default: 'v'
+      update-major-tag:
+        description: 'Update major version tag (v1, v2, etc.)'
+        type: boolean
+        required: false
+        default: true
+      create-github-release:
+        description: 'Create GitHub release'
+        type: boolean
+        required: false
+        default: true
+      generate-release-notes:
+        description: 'Auto-generate release notes'
+        type: boolean
+        required: false
+        default: true
+      custom-release-notes:
+        description: 'Custom release notes content'
+        type: string
+        required: false
+        default: ''
+      validate-action:
+        description: 'Validate action.yml structure'
+        type: boolean
+        required: false
+        default: true
+      dry-run:
+        description: 'Perform a dry run (no actual changes)'
+        type: boolean
+        required: false
+        default: false
+      runner-label:
+        description: 'Runner label'
+        type: string
+        required: false
+        default: 'ubuntu-latest'
+    secrets:
+      github-token:
+        description: 'GitHub token for creating releases and tags'
+        required: true
+    outputs:
+      version:
+        description: 'Released version'
+        value: ${{ jobs.release.outputs.version }}
+      tag:
+        description: 'Created tag'
+        value: ${{ jobs.release.outputs.tag }}
+      major-tag:
+        description: 'Updated major version tag'
+        value: ${{ jobs.release.outputs.major-tag }}
+
+jobs:
+  validate:
+    name: Validate Action
+    runs-on: ${{ inputs.runner-label }}
+    timeout-minutes: 5
+    if: ${{ inputs.validate-action }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Validate action.yml
+        shell: bash
+        run: |
+          if [ ! -f "action.yml" ]; then
+            echo "action.yml not found in repository root"
+            exit 1
+          fi
+          
+          if ! grep -q "^name:" action.yml; then
+            echo "action.yml missing 'name' field"
+            exit 1
+          fi
+          
+          if ! grep -q "^description:" action.yml; then
+            echo "action.yml missing 'description' field"
+            exit 1
+          fi
+          
+          if ! grep -q "^runs:" action.yml; then
+            echo "action.yml missing 'runs' section"
+            exit 1
+          fi
+          
+          if ! grep -A 5 "^runs:" action.yml | grep -q "using:"; then
+            echo "action.yml missing 'using' field in runs section"
+            exit 1
+          fi
+          
+          echo "action.yml structure is valid"
+
+  release:
+    name: Release
+    needs: validate
+    runs-on: ${{ inputs.runner-label }}
+    timeout-minutes: 10
+    outputs:
+      version: ${{ steps.tag.outputs.new_version }}
+      tag: ${{ steps.tag.outputs.new_tag }}
+      major-tag: ${{ steps.major-tag.outputs.major-tag }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.github-token }}
+
+      - name: Bump version and create tag
+        id: tag
+        uses: mathieudutour/github-tag-action@v6.2
+        with:
+          github_token: ${{ secrets.github-token }}
+          default_bump: ${{ inputs.default-bump }}
+          release_branches: ${{ inputs.release-branches }}
+          tag_prefix: ${{ inputs.tag-prefix }}
+          dry_run: ${{ inputs.dry-run }}
+
+      - name: Update major version tag
+        id: major-tag
+        if: ${{ inputs.update-major-tag && steps.tag.outputs.new_tag != '' && !inputs.dry-run }}
+        run: |
+          MAJOR=$(echo ${{ steps.tag.outputs.new_tag }} | cut -d. -f1)
+          echo "major-tag=$MAJOR" >> "$GITHUB_OUTPUT"
+          
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          
+          git tag -d $MAJOR 2>/dev/null || true
+          git push origin :refs/tags/$MAJOR 2>/dev/null || true
+          
+          git tag -a $MAJOR -m "Update $MAJOR to ${{ steps.tag.outputs.new_tag }}"
+          git push origin $MAJOR
+
+      - name: Create GitHub Release
+        if: ${{ inputs.create-github-release && steps.tag.outputs.new_tag != '' && !inputs.dry-run }}
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.tag.outputs.new_tag }}
+          name: Release ${{ steps.tag.outputs.new_tag }}
+          body: ${{ inputs.custom-release-notes || format('Release {0}', steps.tag.outputs.new_tag) }}
+          generate_release_notes: ${{ inputs.generate-release-notes }}
+          token: ${{ secrets.github-token }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.github-token }}
+
+      - name: Output results
+        if: always()
+        shell: bash
+        run: |
+          echo "Release Summary:"
+          echo "  Version: ${{ steps.tag.outputs.new_version || 'N/A' }}"
+          echo "  Tag: ${{ steps.tag.outputs.new_tag || 'N/A' }}"
+          echo "  Major Tag: ${{ steps.major-tag.outputs.major-tag || 'N/A' }}"
+          echo "  Dry Run: ${{ inputs.dry-run }}"


### PR DESCRIPTION
## Summary

Adds two self-contained reusable workflows for GitHub Actions repositories:

### `pr-check-github-action.yml`
- Validates `action.yml` structure (name, description, runs.using)
- Runs `actionlint` on action and workflow files
- Optional test job for action reference validation
- **Inputs**: `runner-label`, `validate-structure`, `run-lint`, `run-test`, `fail-on-missing`

### `release-github-action.yml`
- Bumps version via conventional commits (`mathieudutour/github-tag-action@v6.2`)
- Creates semantic version tags
- Updates major version tags (`v0`, `v1`, etc.)
- Creates GitHub Releases with auto-generated notes
- **Inputs**: `default-bump`, `release-branches`, `tag-prefix`, `update-major-tag`, `create-github-release`, `generate-release-notes`, `custom-release-notes`, `validate-action`, `dry-run`, `runner-label`

## Design Decisions
- **No dependencies** on other composite actions in the repo — workflows are completely self-contained
- Versioning is derived purely from **git tags + conventional commits** (not from `action.yml`)
- PR checks are read-only validation — never modify source files

## Usage

```yaml
# PR checks
jobs:
  check:
    uses: calavia-org/workflows-lib/.github/workflows/pr-check-github-action@v0
    with:
      run-lint: true

# Release
jobs:
  release:
    uses: calavia-org/workflows-lib/.github/workflows/release-github-action@v0
    with:
      default-bump: patch
      release-branches: main
    secrets:
      github-token: ${{ secrets.GITHUB_TOKEN }}
```