### PR TITLE
fix(ci): fix release workflow for workflow-only repo

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,6 @@ jobs:
   release:
     uses: calavia-org/workflows-lib/.github/workflows/release-github-action.yml@v0
     with:
-      version-file: 'none'
+      validate-action: false
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What
Remove invalid `version-file: 'none'` input that caused startup_failure.
Add `validate-action: false` since workflows-lib has no root action.yml.

## Why
The release workflow was failing because `release-github-action.yml` doesn't accept a `version-file` input.

## Changes
- .github/workflows/release.yml: Remove invalid input, set validate-action: false