### PR TITLE
fix(ci): fix release skip and remove unnecessary CI trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,6 @@ name: CI
 on:
   pull_request:
     branches: [main, 'release/*']
-  push:
-    branches: [main, 'release/*']
 
 jobs:
   pr-check:

--- a/.github/workflows/release-github-action.yml
+++ b/.github/workflows/release-github-action.yml
@@ -113,6 +113,7 @@ jobs:
     needs: validate
     runs-on: ${{ inputs.runner-label }}
     timeout-minutes: 10
+    if: always() && !cancelled()
     outputs:
       version: ${{ steps.tag.outputs.new_version }}
       tag: ${{ steps.tag.outputs.new_tag }}


### PR DESCRIPTION
## What
- Add `if: always() && !cancelled()` to release job so it runs even when validate is skipped
- Remove `push` trigger from ci.yml (PR checks only needed on PRs, not after merge)

## Why
1. Release was skipped because `release` job has `needs: validate`, but validate was skipped (validate-action: false). GitHub Actions skips dependent jobs when dependencies are skipped unless `if: always()` is set.
2. CI workflow was running on push to main, but PR check workflow isn't needed after merge.