### PR TITLE
fix(ci): remove needs:validate from release job

### DIFF
--- a/.github/workflows/release-github-action.yml
+++ b/.github/workflows/release-github-action.yml
@@ -110,10 +110,8 @@ jobs:
 
   release:
     name: Release
-    needs: validate
     runs-on: ${{ inputs.runner-label }}
     timeout-minutes: 10
-    if: always() && !cancelled()
     outputs:
       version: ${{ steps.tag.outputs.new_version }}
       tag: ${{ steps.tag.outputs.new_tag }}


### PR DESCRIPTION
## What
Remove `needs: validate` from the release job in release-github-action.yml.

## Why
When `validate-action: false`, the validate job is skipped entirely. Even with `if: always()`, GitHub Actions doesn't run jobs that depend on skipped jobs. Making the jobs independent ensures release runs regardless of whether validation was skipped.

## Changes
- .github/workflows/release-github-action.yml: Remove needs:validate from release job