### PR TITLE
fix(ci): simplify CI to just lint workflow files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,37 @@ on:
     branches: [main, 'release/*']
 
 jobs:
-  pr-check:
-    uses: calavia-org/workflows-lib/.github/workflows/pr-check-github-action.yml@v0
-    with:
-      validate-action: false
-      run-lint: true
-      run-test: false
+  lint:
+    name: Lint Workflows
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Install actionlint
+        shell: bash
+        run: |
+          ARCH=$(uname -m)
+          case "$ARCH" in
+            x86_64) ARCH="amd64" ;;
+            aarch64|arm64) ARCH="arm64" ;;
+          esac
+          OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+          VERSION=$(curl -sL "https://api.github.com/repos/rhysd/actionlint/releases/latest" | python3 -c "import sys, json; print(json.load(sys.stdin)['tag_name'].lstrip('v'))")
+          curl -sL "https://github.com/rhysd/actionlint/releases/download/v${VERSION}/actionlint_${VERSION}_${OS}_${ARCH}.tar.gz" | tar xz
+          sudo mv actionlint /usr/local/bin/
+          echo "actionlint installed"
+
+      - name: Run actionlint
+        shell: bash
+        run: |
+          echo "Running actionlint on workflow files..."
+          
+          if [ -d ".github/workflows" ]; then
+            actionlint .github/workflows/*.yml .github/workflows/*.yaml
+          else
+            echo "No .github/workflows directory found, skipping"
+          fi
+          
+          echo "Linting complete"


### PR DESCRIPTION
## What
Replace reusable pr-check-github-action with a simple actionlint job.

## Why
Workflows-lib is a collection of reusable workflows, not a standalone action. The pr-check-github-action.yml was designed for action repos and added unnecessary complexity (detect job, conditional skips, etc.) when all we need is actionlint on workflow files.

## Changes
- .github/workflows/ci.yml: Simple workflow that runs actionlint on .github/workflows/*.yml